### PR TITLE
Allow parallel apps for multiple concurrent AVA tests.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0",
   "description": "Boilerplate project for building Isomorphic apps using React and Redux",
   "scripts": {
-    "test": "cross-env NODE_ENV=test PORT=8080 MONGO_URL=mongodb://localhost:27017/mern-test node_modules/.bin/nyc node --harmony-proxies node_modules/.bin/ava",
+    "test": "cross-env NODE_ENV=test PORT=0 node_modules/.bin/nyc node --harmony-proxies node_modules/.bin/ava",
     "watch:test": "npm run test -- --watch",
     "cover": "nyc npm run test",
     "check-coverage": "nyc check-coverage --statements 100 --branches 100 --functions 100 --lines 100",

--- a/server/models/__tests__/post.spec.js
+++ b/server/models/__tests__/post.spec.js
@@ -10,11 +10,17 @@ const posts = [
   new Post({ name: 'Mayank', title: 'Hi Mern', slug: 'hi-mern', cuid: 'f34gb2bh24b24b3', content: "All dogs bark 'mern!'" }),
 ];
 
-test.beforeEach('connect and add two post entries', t => {
-  connectDB(t, () => {
-    Post.create(posts, err => {
-      if (err) t.fail('Unable to create posts');
-    });
+
+test.before('connect to mockgoose db', t => {
+  // No need to await here because Model.create promise will not resolve until connection is complete.
+  connectDB(t);
+});
+
+
+test.beforeEach('add two post entries', async t => {
+  // Must await here to be sure data is available before running test.
+  await Post.create(posts, err => {
+    if (err) t.fail('Unable to create posts');
   });
 });
 

--- a/server/server.js
+++ b/server/server.js
@@ -39,16 +39,18 @@ import serverConfig from './config';
 // Set native promises as mongoose promise
 mongoose.Promise = global.Promise;
 
-// MongoDB Connection
-mongoose.connect(serverConfig.mongoURL, (error) => {
-  if (error) {
-    console.error('Please make sure Mongodb is installed and running!'); // eslint-disable-line no-console
-    throw error;
-  }
+// MongoDB Connection; will be initialized later in test environment.
+if (process.env.NODE_ENV !== 'test') {
+  mongoose.connect(serverConfig.mongoURL, (error) => {
+    if (error) {
+      console.error('Please make sure Mongodb is installed and running!'); // eslint-disable-line no-console
+      throw error;
+    }
 
-  // feed some dummy data in DB.
-  dummyData();
-});
+    // feed some dummy data in DB.
+    dummyData();
+  });
+}
 
 // Apply body Parser and server public assets and routes
 app.use(compression());

--- a/server/util/test-helpers.js
+++ b/server/util/test-helpers.js
@@ -1,11 +1,10 @@
 import mongoose from 'mongoose';
 import mockgoose from 'mockgoose';
 
-export function connectDB(t, done) {
+export function connectDB(t) {
   mockgoose(mongoose).then(() => {
-    mongoose.createConnection('mongodb://localhost:27017/mern-test', err => {
+    mongoose.connect('mongodb://mockhost:1/mern-test', err => {
       if (err) t.fail('Unable to connect to test database');
-      done();
     });
   });
 }


### PR DESCRIPTION
Prevent early mongoose connection in server.js under test environment so that tests can run without a real mongo database available.
Await Model.create promise so that tests will not run before test data is created.
Altered mockgoose URL to prove mockgoose is not connecting to a real mongoDB server.